### PR TITLE
Fix code scanning alert no. 10: Useless regular-expression character escape

### DIFF
--- a/src/vs/workbench/contrib/replNotebook/browser/replEditorInput.ts
+++ b/src/vs/workbench/contrib/replNotebook/browser/replEditorInput.ts
@@ -69,7 +69,7 @@ export class ReplEditorInput extends NotebookEditorInput implements ICompositeNo
 		}
 
 		if (resource.scheme === 'untitled') {
-			const match = new RegExp('Untitled-(\\d+)\.').exec(resource.path);
+			const match = new RegExp('Untitled-(\\d+)\\.').exec(resource.path);
 			if (match?.length === 2) {
 				return `REPL - ${match[1]}`;
 			}


### PR DESCRIPTION
Fixes [https://github.com/akaday/vscode/security/code-scanning/10](https://github.com/akaday/vscode/security/code-scanning/10)

To fix the problem, we need to ensure that the period character in the regular expression is treated as a literal period rather than a wildcard. This can be achieved by using a double backslash `\\.` in the string literal, which will be interpreted as a single backslash followed by a period in the regular expression.

- Change the regular expression on line 72 to use `\\.` instead of `\.`.
- This change should be made in the file `src/vs/workbench/contrib/replNotebook/browser/replEditorInput.ts`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
