### PR TITLE
Fix code scanning alert no. 7: Information exposure through a stack trace

### DIFF
--- a/src/vs/workbench/api/node/extHostCLIServer.ts
+++ b/src/vs/workbench/api/node/extHostCLIServer.ts
@@ -80,9 +80,10 @@ export class CLIServerBase {
 	}
 
 	private onRequest(req: http.IncomingMessage, res: http.ServerResponse): void {
-		const sendResponse = (statusCode: number, returnObj: string | undefined) => {
+		const sendResponse = (statusCode: number, returnObj: string | undefined, isError: boolean = false) => {
 			res.writeHead(statusCode, { 'content-type': 'application/json' });
-			res.end(JSON.stringify(returnObj || null), (err?: any) => err && this.logService.error(err)); // CodeQL [SM01524] Only the message portion of errors are passed in.
+			const response = isError ? { error: "An error occurred" } : returnObj;
+			res.end(JSON.stringify(response || null), (err?: any) => err && this.logService.error(err)); // CodeQL [SM01524] Only the message portion of errors are passed in.
 		};
 
 		const chunks: string[] = [];
@@ -112,7 +113,7 @@ export class CLIServerBase {
 				sendResponse(200, returnObj);
 			} catch (e) {
 				const message = e instanceof Error ? e.message : JSON.stringify(e);
-				sendResponse(500, message);
+				sendResponse(500, undefined, true);
 				this.logService.error('Error while processing pipe request', e);
 			}
 		});


### PR DESCRIPTION
Fixes [https://github.com/akaday/vscode/security/code-scanning/7](https://github.com/akaday/vscode/security/code-scanning/7)

To fix the problem, we need to ensure that the error message sent to the client does not contain sensitive information. Instead of sending the actual error message, we should send a generic error message. The detailed error should be logged on the server for debugging purposes.

- Modify the `sendResponse` function to send a generic error message when an error occurs.
- Ensure that the detailed error message and stack trace are logged on the server.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
