### PR TITLE
Fix code scanning alert no. 9: Useless regular-expression character escape

### DIFF
--- a/extensions/json/build/update-grammars.js
+++ b/extensions/json/build/update-grammars.js
@@ -9,7 +9,7 @@ var updateGrammar = require('vscode-grammar-updater');
 function adaptJSON(grammar, name, replacementScope, replaceeScope = 'json') {
 	grammar.name = name;
 	grammar.scopeName = `source${replacementScope}`;
-	const regex = new RegExp(`\.${replaceeScope}`, 'g');
+	const regex = new RegExp(`\\.${replaceeScope}`, 'g');
 	var fixScopeNames = function (rule) {
 		if (typeof rule.name === 'string') {
 			rule.name = rule.name.replace(regex, replacementScope);


### PR DESCRIPTION
Fixes [https://github.com/akaday/vscode/security/code-scanning/9](https://github.com/akaday/vscode/security/code-scanning/9)

To fix the problem, we need to ensure that the regular expression correctly matches a literal dot character. This can be achieved by using double backslashes in the string literal to escape the dot properly. Specifically, we should change `\.` to `\\.` in the regular expression string.

- Update the regular expression on line 12 to use `\\.` instead of `\.`.
- This change ensures that the regular expression matches a literal dot character, preserving the intended functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
