### PR TITLE
Fix code scanning alert no. 35: Prototype-polluting function

### DIFF
--- a/src/vs/base/common/objects.ts
+++ b/src/vs/base/common/objects.ts
@@ -93,6 +93,9 @@ export function mixin(destination: any, source: any, overwrite: boolean = true):
 
 	if (isObject(source)) {
 		Object.keys(source).forEach(key => {
+			if (key === '__proto__' || key === 'constructor') {
+				return;
+			}
 			if (key in destination) {
 				if (overwrite) {
 					if (isObject(destination[key]) && isObject(source[key])) {


### PR DESCRIPTION
Fixes [https://github.com/akaday/vscode/security/code-scanning/35](https://github.com/akaday/vscode/security/code-scanning/35)

To fix the prototype pollution vulnerability in the `mixin` function, we need to ensure that properties like `__proto__` and `constructor` are not copied from the `source` object to the `destination` object. This can be achieved by adding a check to skip these properties during the merge process.

**Steps to fix:**
1. Modify the `mixin` function to include a check that skips the `__proto__` and `constructor` properties.
2. Ensure that this check is applied before any assignment to the `destination` object.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
