### PR TITLE
Fix code scanning alert no. 37: Shell command built from environment values

### DIFF
--- a/build/azure-pipelines/publish-types/update-types.ts
+++ b/build/azure-pipelines/publish-types/update-types.ts
@@ -16,7 +16,7 @@ try {
 
 	const dtsUri = `https://raw.githubusercontent.com/microsoft/vscode/${tag}/src/vscode-dts/vscode.d.ts`;
 	const outPath = path.resolve(process.cwd(), 'DefinitelyTyped/types/vscode/index.d.ts');
-	cp.execSync(`curl ${dtsUri} --output ${outPath}`);
+	cp.execFileSync('curl', [dtsUri, '--output', outPath]);
 
 	updateDTSFile(outPath, tag);
 


### PR DESCRIPTION
Fixes [https://github.com/akaday/vscode/security/code-scanning/37](https://github.com/akaday/vscode/security/code-scanning/37)

To fix the problem, we should avoid constructing the shell command as a single string and instead use `cp.execFileSync` to pass the command and its arguments separately. This approach ensures that the shell does not misinterpret any special characters in the arguments.

1. Replace the `cp.execSync` call with `cp.execFileSync`.
2. Pass the command (`curl`) and its arguments (`dtsUri`, `--output`, `outPath`) as separate parameters to `cp.execFileSync`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
