### PR TITLE
Fix code scanning alert no. 38: Use of a broken or weak cryptographic algorithm

### DIFF
--- a/src/vs/platform/languagePacks/node/languagePacks.ts
+++ b/src/vs/platform/languagePacks/node/languagePacks.ts
@@ -170,11 +170,11 @@ class LanguagePacksCache extends Disposable {
 
 	private updateHash(languagePack: ILanguagePack): void {
 		if (languagePack) {
-			const md5 = createHash('md5'); // CodeQL [SM04514] Used to create an hash for language pack extension version, which is not a security issue
+			const sha256 = createHash('sha256'); // CodeQL [SM04514] Used to create a hash for language pack extension version, which is not a security issue
 			for (const extension of languagePack.extensions) {
-				md5.update(extension.extensionIdentifier.uuid || extension.extensionIdentifier.id).update(extension.version); // CodeQL [SM01510] The extension UUID is not sensitive info and is not manually created by a user
+				sha256.update(extension.extensionIdentifier.uuid || extension.extensionIdentifier.id).update(extension.version); // CodeQL [SM01510] The extension UUID is not sensitive info and is not manually created by a user
 			}
-			languagePack.hash = md5.digest('hex');
+			languagePack.hash = sha256.digest('hex');
 		}
 	}
 


### PR DESCRIPTION
Fixes [https://github.com/akaday/vscode/security/code-scanning/38](https://github.com/akaday/vscode/security/code-scanning/38)

To fix the problem, we should replace the use of the MD5 hashing algorithm with a stronger algorithm like SHA-256. This change will ensure that the hash function used is secure and resistant to collision attacks.

- **General Fix**: Replace `createHash('md5')` with `createHash('sha256')`.
- **Detailed Fix**: Update the `updateHash` method in the `LanguagePacksCache` class to use SHA-256 instead of MD5.
- **Specific Changes**:
  - Change the `createHash('md5')` call to `createHash('sha256')` on line 173.
  - Ensure that the rest of the code remains unchanged to maintain existing functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
