### PR TITLE
Fix code scanning alert no. 12: DOM text reinterpreted as HTML

### DIFF
--- a/extensions/media-preview/media/imagePreview.js
+++ b/extensions/media-preview/media/imagePreview.js
@@ -21,7 +21,13 @@
 		if (element) {
 			const data = element.getAttribute('data-settings');
 			if (data) {
-				return JSON.parse(data);
+				const settings = JSON.parse(data);
+				try {
+					settings.src = new URL(settings.src).toString();
+				} catch (e) {
+					throw new Error('Invalid URL in settings.src');
+				}
+				return settings;
 			}
 		}
 


### PR DESCRIPTION
Fixes [https://github.com/akaday/vscode/security/code-scanning/12](https://github.com/akaday/vscode/security/code-scanning/12)

To fix the problem, we need to ensure that the `settings.src` value is properly sanitized before being used. One way to achieve this is by using a URL parser to validate and sanitize the URL. This will prevent any malicious content from being executed.

- We will use the `URL` constructor to parse and validate the `settings.src` value.
- If the `settings.src` value is not a valid URL, we will throw an error to prevent the assignment.
- This change will be made in the `getSettings` function where the `settings` object is created.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
