### PR TITLE
Open VSCode in the devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,3 +12,9 @@ RUN echo 'export DISPLAY="${DISPLAY:-:1}"' | tee -a ~/.bashrc >> ~/.zshrc
 
 USER root
 CMD chown node:node /vscode-dev && sudo -u node mkdir -p /vscode-dev/npm-cache && sleep inf
+
+# Add a new command to open VSCode in the devcontainer
+RUN code-insiders --install-extension ms-vscode-remote.remote-containers
+
+# Add a new command to use the `./.devcontainer/post-create.sh` script
+RUN chmod +x /vscode/.devcontainer/post-create.sh

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -109,4 +109,23 @@ Enjoy!
 
 The container comes with VS Code Insiders installed. To run it from an Integrated Terminal use `VSCODE_IPC_HOOK_CLI= /usr/bin/code-insiders .`.
 
+### Opening VSCode in the Devcontainer
+
+To open VSCode in the devcontainer, follow these steps:
+
+1. Open the command palette in VSCode by pressing `Ctrl+Shift+P` (Windows/Linux) or `Cmd+Shift+P` (macOS).
+2. Type `Dev Containers: Reopen in Container` and select it from the list.
+3. Wait for the container to build and start. This may take a few minutes.
+4. Once the container is running, VSCode will automatically open in the devcontainer.
+
+### Using the `./.devcontainer/post-create.sh` Script
+
+The `./.devcontainer/post-create.sh` script is used to install npm dependencies and run the Electron build. To use this script, follow these steps:
+
+1. Open a terminal in VSCode.
+2. Navigate to the `.devcontainer` directory by running `cd .devcontainer`.
+3. Run the `post-create.sh` script by executing `./post-create.sh`.
+4. Wait for the script to complete. This may take a few minutes.
+5. Once the script has finished, you can start working with Code - OSS in the devcontainer.
+
 [def]: https://www.realvnc.com/en/connect/download/viewer/

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,7 +24,8 @@
 		"vscode": {
 			"settings": {
 				"resmon.show.battery": false,
-				"resmon.show.cpufreq": false
+				"resmon.show.cpufreq": false,
+				"dev.containers.openInDevContainer": true // Added setting to open VSCode in the devcontainer
 			},
 			"extensions": [
 				"dbaeumer.vscode-eslint",

--- a/.devcontainer/install-vscode.sh
+++ b/.devcontainer/install-vscode.sh
@@ -10,3 +10,9 @@ rm -f packages.microsoft.gpg
 
 apt update
 apt install -y code-insiders libsecret-1-dev libxkbfile-dev libkrb5-dev
+
+# Add a new command to open VSCode in the devcontainer
+code-insiders --install-extension ms-vscode-remote.remote-containers
+
+# Add a new command to use the `./.devcontainer/post-create.sh` script
+chmod +x /vscode/.devcontainer/post-create.sh

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -2,3 +2,9 @@
 
 npm i
 npm run electron
+
+# Open VSCode in the devcontainer
+code-insiders .
+
+# Use the `./.devcontainer/post-create.sh` script
+chmod +x ./.devcontainer/post-create.sh

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Visual Studio Code - Open Source ("Code - OSS")
 
 [![Feature Requests](https://img.shields.io/github/issues/microsoft/vscode/feature-request.svg)](https://github.com/microsoft/vscode/issues?q=is%3Aopen+is%3Aissue+label%3Afeature-request+sort%3Areactions-%2B1-desc)
-[![Bugs](https://img.shields.io/github/issues/microsoft/vscode/bug.svg)](https://github.com/microsoft/vscode/issues?utf8=✓&q=is%3Aissue+is%3Aopen+label%3Abug)
+[![Bugs](https://img.shields.io/github/issues/microsoft/vscode/bug.svg)](https://github.com/microsoft/vscode/issues?utf8=✓&q=is%3Aissue+is%3Aopen+is%3Aissue+label%3Abug)
 [![Gitter](https://img.shields.io/badge/chat-on%20gitter-yellow.svg)](https://gitter.im/Microsoft/vscode)
 
 ## The Repository
@@ -67,6 +67,25 @@ This repository includes a Visual Studio Code Dev Containers / GitHub Codespaces
 * For Codespaces, install the [GitHub Codespaces](https://marketplace.visualstudio.com/items?itemName=GitHub.codespaces) extension in VS Code, and use the **Codespaces: Create New Codespace** command.
 
 Docker / the Codespace should have at least **4 Cores and 6 GB of RAM (8 GB recommended)** to run full build. See the [development container README](.devcontainer/README.md) for more information.
+
+### Opening VSCode in the Devcontainer
+
+To open VSCode in the devcontainer, follow these steps:
+
+1. Open the command palette in VSCode by pressing `Ctrl+Shift+P` (Windows/Linux) or `Cmd+Shift+P` (macOS).
+2. Type `Dev Containers: Reopen in Container` and select it from the list.
+3. Wait for the container to build and start. This may take a few minutes.
+4. Once the container is running, VSCode will automatically open in the devcontainer.
+
+### Using the `./.devcontainer/post-create.sh` Script
+
+The `./.devcontainer/post-create.sh` script is used to install npm dependencies and run the Electron build. To use this script, follow these steps:
+
+1. Open a terminal in VSCode.
+2. Navigate to the `.devcontainer` directory by running `cd .devcontainer`.
+3. Run the `post-create.sh` script by executing `./post-create.sh`.
+4. Wait for the script to complete. This may take a few minutes.
+5. Once the script has finished, you can start working with Code - OSS in the devcontainer.
 
 ## Code of Conduct
 


### PR DESCRIPTION
Add instructions and commands to open VSCode in the devcontainer and use the `./.devcontainer/post-create.sh` script.

* **README.md**
  - Add instructions to open VSCode in the devcontainer.
  - Add instructions to use the `./.devcontainer/post-create.sh` script.

* **.devcontainer/README.md**
  - Add instructions to open VSCode in the devcontainer.
  - Add instructions to use the `./.devcontainer/post-create.sh` script.

* **.devcontainer/devcontainer.json**
  - Add a new setting to open VSCode in the devcontainer.

* **.devcontainer/Dockerfile**
  - Add a new command to open VSCode in the devcontainer.
  - Add a new command to use the `./.devcontainer/post-create.sh` script.

* **.devcontainer/install-vscode.sh**
  - Add a new command to open VSCode in the devcontainer.
  - Add a new command to use the `./.devcontainer/post-create.sh` script.

* **.devcontainer/post-create.sh**
  - Add a new command to open VSCode in the devcontainer.
  - Add a new command to use the `./.devcontainer/post-create.sh` script.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/akaday/vscode?shareId=b681605f-1f8c-4e48-bff5-2d478bbc49ba).