### PR TITLE
Fix code scanning alert no. 44: Useless regular-expression character escape

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/suggest/test/browser/terminalSuggestAddon.integrationTest.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/test/browser/terminalSuggestAddon.integrationTest.ts
@@ -181,7 +181,7 @@ suite('Terminal Contrib Suggest Recordings', () => {
 									});
 								}
 							}));
-						} else if (event.data.match('\x1b]633;Completions;.+\[.+\]')) {
+						} else if (event.data.match('\x1b]633;Completions;.+\[.+]')) {
 							// If the output contains a pwsh completions sequence with results, wait for the associated
 							// suggest addon event until proceeding.
 							promises.push(new Promise<void>(r => {


### PR DESCRIPTION
Fixes [https://github.com/akaday/vscode/security/code-scanning/44](https://github.com/akaday/vscode/security/code-scanning/44)

To fix the problem, we need to remove the unnecessary escape sequence `\]` from the regular expression. This can be done by simply replacing `\]` with `]` in the regular expression string. This change will not affect the functionality of the code but will make the regular expression clearer and more maintainable.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
